### PR TITLE
Remove misleading "Finished" message (Fixes #21)

### DIFF
--- a/draft-fossati-tls-exported-attestation.md
+++ b/draft-fossati-tls-exported-attestation.md
@@ -220,8 +220,6 @@ Client                   Server                   Verifier
   | CertificateVerify,     |                         |
   | Finished)              |                         |
   |----------------------->|                         |
-  |                        |      Finished           |
-  |                        |<------------------------|
 ~~~
 {: #fig-passport title="Passport Model with Client as Attester"}
 


### PR DESCRIPTION
Remove misleading "Finished" message from Verifier to server in passport model